### PR TITLE
Centralize corner items

### DIFF
--- a/src/carousel.js
+++ b/src/carousel.js
@@ -43,6 +43,7 @@ class Carousel extends Component {
       data,
       containerWidth,
       initialIndex,
+      onItemSelected,
     } = this.props;
     this.currentIndex = initialIndex;
     this.scrollXBegin = 0;
@@ -50,11 +51,18 @@ class Carousel extends Component {
     this.halfContainerWidth = containerWidth / 2;
     this.halfItemWidth = itemWidth / 2;
     this.alwaysCentralizeSelected = alwaysCentralizeSelected;
+    this.onItemSelected = onItemSelected;
     this.data = this.alwaysCentralizeSelected ?
        [this.Constants.dummyItem, ...data,  this.Constants.dummyItem]: data
     this.lastIndex = this.data.length - 1;
   }
-  
+
+  componentDidMount(){
+    if(this.onItemSelected){
+      this.onItemSelected(this.data[this.currentIndex]);
+    }
+  }
+
   setScrollHandler() {
     this.handleOnScroll = Animated.event(
       [{ nativeEvent: { contentOffset: { x: this.xOffset } } }],
@@ -72,6 +80,9 @@ class Carousel extends Component {
     if (index < 0 || index >= this.data.length) return;
     onScrollEnd(this.data[index], index);
     this.currentIndex = index;
+    if(this.onItemSelected && (!this.alwaysCentralizeSelected || (index > 0 && index<this.lastIndex))){
+     this.onItemSelected(this.data[index]);
+    }
     setTimeout(() => {
       this._scrollView.getNode().scrollToOffset({
         offset:

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -240,6 +240,7 @@ class Carousel extends Component {
       itemWidth,
       containerWidth,
       initialIndex,
+      alwaysSnapCenter,
       ...otherProps
     } = this.props;
     return (
@@ -260,6 +261,8 @@ class Carousel extends Component {
         onScroll={this.handleOnScroll}
         onScrollEndDrag={this.handleOnScrollEndDrag}
         getItemLayout={this.getItemLayout}
+        onTouchStart={alwaysSnapCenter ? this.handleOnScrollBeginDrag: null}
+        onTouchEnd={alwaysSnapCenter ? this.handleOnScrollEndDrag: null}
         //scrollEnabled//snapToInterval={itemWidth}
       />
     );

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -79,6 +79,7 @@ class Carousel extends Component {
   scrollToIndex(index) {
     const { onScrollEnd, itemWidth, separatorWidth } = this.props;
     if (index < 0 || index >= this.data.length) return;
+    if(this.alwaysCentralizeSelected  && (index === 0 || index === this.data.length-1)) return;
     onScrollEnd(this.data[index], index);
     this.currentIndex = index;
     if(this.onItemSelected && (!this.alwaysCentralizeSelected || (index > 0 && index<this.lastIndex))){
@@ -112,16 +113,22 @@ class Carousel extends Component {
       this.scrollToIndex(this.currentIndex);
       return;
     }
-    scrollDistance < 0
-      ? this.scrollToIndex(this.currentIndex - 1)
-      : this.scrollToIndex(this.currentIndex + 1);
-
-    if(this.alwaysCentralizeSelected){
-      if(this.currentIndex === 0 && this.lastIndex > 0){
-        this.scrollToIndex(1);
+    
+    if(scrollDistance < 0){
+      if(this.alwaysCentralizeSelected && this.currentIndex === 1){
+        this.scrollToIndex(this.currentIndex);
       }
-      if(this.currentIndex === this.lastIndex && this.currentIndex > 0){
-        this.scrollToIndex(this.lastIndex-1);
+      else{
+        this.scrollToIndex(this.currentIndex - 1);
+      }
+    }
+    else {
+      if(this.alwaysCentralizeSelected && this.currentIndex === this.lastIndex-1){
+        this.scrollToIndex(this.currentIndex);
+      }
+
+      else{
+        this.scrollToIndex(this.currentIndex + 1)
       }
     }
   }

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -5,7 +5,8 @@ import {
   TouchableWithoutFeedback,
   Dimensions,
   ViewPropTypes,
-  FlatList
+  FlatList,
+  Platform,
 } from 'react-native';
 import PropTypes from 'prop-types';
 
@@ -243,6 +244,7 @@ class Carousel extends Component {
       alwaysSnapCenter,
       ...otherProps
     } = this.props;
+    const isIOS = (Platform.OS === 'ios');
     return (
       <AnimatedFlatList
         {...otherProps}
@@ -261,8 +263,8 @@ class Carousel extends Component {
         onScroll={this.handleOnScroll}
         onScrollEndDrag={this.handleOnScrollEndDrag}
         getItemLayout={this.getItemLayout}
-        onTouchStart={alwaysSnapCenter ? this.handleOnScrollBeginDrag: null}
-        onTouchEnd={alwaysSnapCenter ? this.handleOnScrollEndDrag: null}
+        onTouchStart={alwaysSnapCenter && !isIOS ? this.handleOnScrollBeginDrag: null}
+        onTouchEnd={alwaysSnapCenter && !isIOS ? this.handleOnScrollEndDrag: null}
         //scrollEnabled//snapToInterval={itemWidth}
       />
     );

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -285,7 +285,9 @@ Carousel.propTypes = {
   minScrollDistance: PropTypes.number,
   onScrollBeginDrag: PropTypes.func,
   onScrollEndDrag: PropTypes.func,
-  data: PropTypes.arrayOf(PropTypes.object)
+  data: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), 
+    PropTypes.arrayOf(PropTypes.string), 
+    PropTypes.arrayOf(PropTypes.number)]),
   //itemHeight: PropTypes.number,
   //containerHeight: PropTypes.number,
 };


### PR DESCRIPTION
refactor: centralize corner items

one way to centralize corner items is to add dummy items as new corner items, and after you scroll to it you can forcefully scroll back to a valid item.

with these changes when a user scrolls to one of the corners he will be scrolled back to the item that is directly before the dummy item.